### PR TITLE
fixed inner join logic

### DIFF
--- a/Nodes Monitoring Scripts/InactiveNodes_Script2.sql
+++ b/Nodes Monitoring Scripts/InactiveNodes_Script2.sql
@@ -33,7 +33,7 @@ WITH inactive_nodes AS (
                 sd."timestamp" DESC
         ) AS sdata ON ss.id = sdata.sensor_id
         INNER JOIN sensors_node sn ON ss.node_id = sn.id
-        INNER JOIN sensors_sensortype st ON ss.sensor_type_id = sensor_type_id
+        INNER JOIN sensors_sensortype st ON ss.sensor_type_id = st.id
         INNER JOIN sensors_sensorlocation sl ON sl.id = sn.location_id
     GROUP BY
         sn.uid,


### PR DESCRIPTION
Bug was in this line `INNER JOIN sensors_sensortype st ON ss.sensor_type_id = sensor_type_id ` which caused duplication of sensor ids 
<img width="1481" alt="Screenshot 2023-07-10 at 10 02 27" src="https://github.com/CodeForAfrica/HTOOLS-AVG_DATA_PSQL_QUERIES/assets/17834362/ef7d4b58-c8f8-4c87-83c0-d45356754fe3">
